### PR TITLE
Start of pulling across the formatter support from rspec-core.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+-r spec_helper

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--exclude features
+--no-private
+--markup markdown
+--default-return void
+-
+Changelog.md
+License.txt

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,4 @@
+### Development
+[Full Changelog](http://github.com/rspec/rspec-legacy_formatters/compare/master...master)
+
+* Extracted from `rspec-core`. (Jon Rowe)

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-%w[rspec rspec-expectations rspec-mocks rspec-support].each do |lib|
+%w[rspec rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
   library_path = File.expand_path("../../#{lib}", __FILE__)
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,0 +1,6 @@
+<%
+exclusions = []
+exclusions << ' --tags ~@no-jruby' if RUBY_PLATFORM == 'java'
+%>
+default: --require features --strict --format progress --tags ~@wip<%= exclusions.join %> features
+wip:     --require features --tags @wip:30 --wip features

--- a/features/custom_formatter.feature
+++ b/features/custom_formatter.feature
@@ -1,0 +1,28 @@
+Feature: Custom formatters
+
+  Scenario: a legacy custom formatter
+    Given a file named "custom_formatter.rb" with:
+      """ruby
+      require "rspec/legacy_formatters"
+      require "rspec/core/formatters/base_text_formatter"
+
+      class CustomFormatter < RSpec::Core::Formatters::BaseTextFormatter
+        def initialize(output)
+          super(output)
+        end
+
+        def example_started(proxy)
+          output << "example: " << proxy.description
+        end
+      end
+      """
+    And a file named "example_spec.rb" with:
+      """ruby
+      describe "my group" do
+        specify "my example" do
+        end
+      end
+      """
+    When I run `rspec example_spec.rb --require ./custom_formatter.rb --format CustomFormatter`
+    Then the output should contain "example: my example"
+    And  the exit status should be 0

--- a/features/regression_tests.feature
+++ b/features/regression_tests.feature
@@ -1,0 +1,90 @@
+Feature: Regression tests for legacy custom formatters
+
+  Background:
+    Given a file named ".rspec" with:
+      """
+      --require rspec/legacy_formatters
+      --require spec_helper
+      """
+      And a file named "spec/spec_helper.rb" with:
+      """
+      RSpec.configure do |rspec|
+        rspec.after(:suite) do
+          puts rspec.formatters.map(&:class).inspect
+        end
+      end
+      """
+      And a file named "spec/passing_and_failing_spec.rb" with:
+      """ruby
+      RSpec.describe "Some examples" do
+        it "passes" do
+          expect(1).to eq(1)
+        end
+
+        it "fails" do
+          expect(1).to eq(2)
+        end
+
+        context "nested" do
+          it "passes" do
+            expect(1).to eq(1)
+          end
+
+          it "fails" do
+            expect(1).to eq(2)
+          end
+        end
+      end
+      """
+      And a file named "spec/pending_spec.rb" with:
+      """ruby
+      RSpec.describe "Some pending examples" do
+        context "pending" do
+          it "is reported as pending" do
+            pending; expect(1).to eq(2)
+          end
+
+          it "is reported as failing" do
+            pending; expect(1).to eq(1)
+          end
+        end
+      end
+      """
+
+  Scenario: Use fuubar formatter
+    When I run `rspec --format Fuubar`
+    Then the output should contain "Progress: |============"
+     And the output should contain "6 examples, 3 failures, 1 pending"
+     And the output should not contain any error backtraces
+     And the output should not contain "ProgressFormatter"
+
+  Scenario: Use rspec-instafail formatter
+    When I run `rspec --format RSpec::Instafail`
+    Then the output should contain "6 examples, 3 failures, 1 pending"
+     And the output should not contain any error backtraces
+     And the output should not contain "ProgressFormatter"
+
+  Scenario: Use rspec-extra-formatters JUnit formatter
+    When I run `rspec --require rspec-extra-formatters --format JUnitFormatter`
+    Then the output should contain:
+      """
+      <testsuite errors="0" failures="3" skipped="1" tests="6"
+      """
+     And the output should not contain any error backtraces
+     And the output should not contain "ProgressFormatter"
+
+  Scenario: Use rspec-extra-formatters Tap formatter
+    When I run `rspec --require rspec-extra-formatters --format TapFormatter`
+    Then the output should contain "TAP version 13"
+     And the output should not contain any error backtraces
+     And the output should not contain "ProgressFormatter"
+
+  @wip
+  Scenario: Use rspec-spinner formatter
+    When I run `rspec --require rspec_spinner --format RspecSpinner::Spinner`
+    Then the output should contain "TBD"
+
+  @wip
+  Scenario: Use nyancat formatter
+    When I run `rspec --format NyanCatFormatter`
+    Then the output should contain "TBD"

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -1,0 +1,3 @@
+Then /^the output should not contain any error backtraces$/ do
+  step %q{the output should not contain "lib/rspec/core"}
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,13 @@
+require 'aruba/cucumber'
+
+timeouts = { 'java' => 60 }
+
+Before do
+  @aruba_timeout_seconds = timeouts.fetch(RUBY_PLATFORM) { 10 }
+end
+
+Aruba.configure do |config|
+  config.before_cmd do |cmd|
+    set_env('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}") # disable JIT since these processes are so short lived
+  end
+end if RUBY_PLATFORM == 'java'

--- a/lib/rspec/legacy_formatters.rb
+++ b/lib/rspec/legacy_formatters.rb
@@ -1,8 +1,21 @@
 require "rspec/legacy_formatters/version"
+require "rspec/legacy_formatters/adaptor"
+require "rspec/core/formatters/helpers"
+require 'stringio'
 
 # Namespace for the rspec code.
 module RSpec
   # Namespace for the rspec-legacy_formatters code.
   module LegacyFormatters
+
+    # Loads legacy formatters into an adaptor.
+    #
+    # @param formatter_class [Class] a legacy formatter class
+    # @param args [Array(IO)] output streams for formatters
+    # @return [Adaptor] a legacy formatter adaptor with an initialized legacy formatter
+    def self.load_formatter(formatter_class, *args)
+      Adaptor.new(formatter_class, *args)
+    end
+
   end
 end

--- a/lib/rspec/legacy_formatters/adaptor.rb
+++ b/lib/rspec/legacy_formatters/adaptor.rb
@@ -1,0 +1,307 @@
+module RSpec
+  module LegacyFormatters
+
+    # @private
+    # The `LegacyFormatter` is used to wrap older RSpec 2.x style formatters
+    # for the new 3.x implementation. It takes care of registering all the
+    # old notifications and translating them to the older formatter.
+    #
+    # @see RSpec::Core::Formatters::BaseFormatter
+    class Adaptor
+      NOTIFICATIONS = %W[start message example_group_started example_group_finished example_started
+                         example_passed example_failed example_pending start_dump dump_pending
+                         dump_failures dump_summary seed close stop deprecation deprecation_summary]
+
+      # @private
+      module LegacyInterface
+
+        def start(count)
+          super Core::Notifications::StartNotification.new(count)
+        end
+
+        def example_group_started(group)
+          super Core::Notifications::GroupNotification.new(group) if defined?(super)
+        end
+
+        def example_group_finished(group)
+          super Core::Notifications::GroupNotification.new(group) if defined?(super)
+        end
+
+        def example_started(example)
+          super Core::Notifications::ExampleNotification.new(example) if defined?(super)
+        end
+
+        def example_passed(example)
+          super Core::Notifications::ExampleNotification.new(example) if defined?(super)
+        end
+
+        def example_pending(example)
+          super Core::Notifications::ExampleNotification.new(example) if defined?(super)
+        end
+
+        def example_failed(example)
+          super Core::Notifications::ExampleNotification.new(example) if defined?(super)
+        end
+
+        def message(message)
+          super Core::Notifications::MessageNotification.new(message) if defined?(super)
+        end
+
+        attr_reader :duration, :example_count, :failure_count, :pending_count
+        attr_accessor :load_time
+        def dump_summary(duration, examples, failures, pending)
+          @duration      = duration
+          @example_count = examples
+          @failure_count = failures
+          @pending_count = pending
+          super Core::Notifications::SummaryNotification.new(duration, examples, failures, pending, self.load_time) if defined?(super)
+        end
+
+        def seed(seed)
+          super Core::Notifications::SeedNotification.new(seed, true) if defined?(super)
+        end
+
+        def start_dump
+          super(Core::Notifications::NullNotification) if defined?(super)
+        end
+
+        def dump_failures
+          super(Core::Notifications::NullNotification) if defined?(super)
+        end
+
+        def dump_pending
+          super(Core::Notifications::NullNotification) if defined?(super)
+        end
+
+        def close
+          super(Core::Notifications::NullNotification) if defined?(super)
+        end
+
+        def stop
+          super(Core::Notifications::NullNotification) if defined?(super)
+        end
+      end
+
+      # @private
+      module LegacyColorSupport
+        def red(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#red", :replacement => "#failure_color")
+          color(text, :red)
+        end
+
+        def green(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#green", :replacement => "#success_color")
+          color(text, :green)
+        end
+
+        def yellow(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#yellow", :replacement => "#pending_color")
+          color(text, :yellow)
+        end
+
+        def blue(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#blue", :replacement => "#fixed_color")
+          color(text, :blue)
+        end
+
+        def magenta(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#magenta")
+          color(text, :magenta)
+        end
+
+        def cyan(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#cyan", :replacement => "#detail_color")
+          color(text, :cyan)
+        end
+
+        def white(text)
+          RSpec.deprecate("RSpec::Core::Formatters::BaseTextFormatter#white", :replacement => "#default_color")
+          color(text, :white)
+        end
+
+        # @private
+        module ConstantLookup
+          def const_missing(name)
+            base_name = "RSpec::Core::Formatters::BaseTextFormatter"
+            case name
+            when :VT100_COLORS then
+              RSpec.deprecate("#{base_name}::VT100_COLORS", :replacement => "RSpec::Core::Formatters::ConsoleCodes.code_for(code_or_symbol)")
+              RSpec::Core::Formatters::ConsoleCodes::VT100_CODES
+            when :VT100_COLOR_CODES then
+              RSpec.deprecate("#{base_name}::VT100_COLOR_CODES", :replacement => "RSpec::Core::Formatters::ConsoleCodes.code_for(code_or_symbol)")
+              RSpec::Core::Formatters::ConsoleCodes::VT100_CODE_VALUES
+            else
+              super
+            end
+          end
+        end
+
+        # These are part of the deprecated interface, so no individual deprecations
+        def color_code_for(code_or_symbol)
+          ::RSpec::Core::Formatters::ConsoleCodes.console_code_for(code_or_symbol)
+        end
+
+        def colorize(text, code_or_symbol)
+          ::RSpec::Core::Formatters::ConsoleCodes.wrap(text, code_or_symbol)
+        end
+
+        def colorize_summary(summary)
+          if failure_count > 0
+            color(summary, RSpec.configuration.failure_color)
+          elsif pending_count > 0
+            color(summary, RSpec.configuration.pending_color)
+          else
+            color(summary, RSpec.configuration.success_color)
+          end
+        end
+      end
+
+      # @api private
+      attr_reader :formatter
+
+      # @api public
+      #
+      # @param formatter_class [Class] formatter class to build
+      # @param args [Array<IO, Object>] arguments for the formatter, (usually IO but don't have to be)
+      def initialize(formatter_class, *args)
+        base_const = ::RSpec::Core::Formatters
+        if defined?(base_const::BaseFormatter) && formatter_class.ancestors.include?(base_const::BaseFormatter)
+          formatter_class.class_exec do
+            include LegacyInterface
+          end
+        end
+        if defined?(base_const::BaseTextFormatter) && formatter_class.ancestors.include?(base_const::BaseTextFormatter)
+          formatter_class.class_exec do
+            include LegacyColorSupport
+            extend  LegacyColorSupport::ConstantLookup
+          end
+        end
+        @formatter = formatter_class.new(*args)
+      end
+
+      # @api public
+      #
+      # This method is invoked during the setup phase to register
+      # a formatters with the reporter
+      #
+      # @return [Array] notifications the legacy formatter implements
+      def notifications
+        @notifications ||= NOTIFICATIONS.select { |m| @formatter.respond_to? m }
+      end
+
+      # @api public
+      #
+      # @param notification [NullNotification]
+      def start(notification)
+        @formatter.start notification.count
+      end
+
+      # @api public
+      #
+      # @param notification [GroupNotification] containing example_group subclass of `RSpec::Core::ExampleGroup`
+      def example_group_started(notification)
+        @formatter.example_group_started notification.group
+      end
+
+      # @api public
+      #
+      # @param notification [GroupNotification] containing example_group subclass of `RSpec::Core::ExampleGroup`
+      def example_group_finished(notification)
+        @formatter.example_group_finished notification.group
+      end
+
+      # @api public
+      #
+      # @param notification [ExampleNotification] containing example subclass of `RSpec::Core::Example`
+      def example_started(notification)
+        @formatter.example_started notification.example
+      end
+
+      # @api public
+      #
+      # @param notification [ExampleNotification] containing example subclass of `RSpec::Core::Example`
+      def example_passed(notification)
+        @formatter.example_passed notification.example
+      end
+
+      # @api public
+      #
+      # @param notification [ExampleNotification] containing example subclass of `RSpec::Core::Example`
+      def example_pending(notification)
+        @formatter.example_pending notification.example
+      end
+
+      # @api public
+      #
+      # @param notification [ExampleNotification] containing example subclass of `RSpec::Core::Example`
+      def example_failed(notification)
+        @formatter.example_failed notification.example
+      end
+
+      # @api public
+      #
+      # @param notification [MessageNotification] containing message
+      def message(notification)
+        @formatter.message notification.message
+      end
+
+      # @api public
+      #
+      # @param notification [NullNotification]
+      def stop(notification)
+        @formatter.stop
+      end
+
+      # @api public
+      #
+      # @param notification [NullNotification]
+      def start_dump(notification)
+        @formatter.start_dump
+      end
+
+      # @api public
+      #
+      # @param notification [NullNotification]
+      def dump_failures(notification)
+        @formatter.dump_failures
+      end
+
+      # @api public
+      #
+      # @param summary [Core::Notifications::SummaryNotification]
+      def dump_summary(summary)
+        @formatter.load_time = summary.load_time if @formatter.respond_to? :load_time
+        @formatter.dump_summary summary.duration, summary.example_count, summary.failure_count, summary.pending_count
+      end
+
+      # @api public
+      #
+      # @param notification [NullNotification]
+      def dump_pending(notification)
+        @formatter.dump_pending
+      end
+
+      # @api public
+      #
+      # @param notification [NullNotification]
+      def dump_profile(notification)
+        @formatter.dump_profile
+      end
+
+      # @api public
+      #
+      # @param notification [SeedNotification] containing the seed
+      def seed(notification)
+        @formatter.seed notification.seed
+      end
+
+      # @api public
+      #
+      # @param notification [NullNotification]
+      def close(notification)
+        @formatter.close
+      end
+
+    end
+  end
+end

--- a/rspec-legacy_formatters.gemspec
+++ b/rspec-legacy_formatters.gemspec
@@ -30,9 +30,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     "rspec-core",    ">= 3.0.0.beta2"
   spec.add_runtime_dependency     "rspec-support", ">= 3.0.0.beta2"
 
-  spec.add_development_dependency "bundler",       "~> 1.5"
-  spec.add_development_dependency "cucumber",      "~> 1.3"
-  spec.add_development_dependency "rake",          "~> 10.0.0"
+  spec.add_development_dependency "bundler",  "~> 1.5"
+  spec.add_development_dependency "cucumber", "~> 1.3"
+  spec.add_development_dependency "aruba",    "~> 0.5"
+  spec.add_development_dependency "rake",     "~> 10.0.0"
 
   # For legacy custom formatter regression tests
   spec.add_development_dependency "fuubar",                 "1.3.2"

--- a/spec/rspec/legacy_formatters_spec.rb
+++ b/spec/rspec/legacy_formatters_spec.rb
@@ -1,0 +1,184 @@
+require 'rspec/core/formatters/console_codes'
+require 'rspec/legacy_formatters'
+
+RSpec.describe RSpec::LegacyFormatters do
+  include FormatterSupport
+
+  it 'can access attributes provided by base class accessors in #initialize' do
+    klass = Class.new(LegacyFormatterUsingSubClassing) do
+      def initialize(*args)
+        example_count
+        super
+      end
+    end
+
+    config.add_formatter klass
+    expect(config.formatters.first).to be_a(RSpec::LegacyFormatters::Adaptor)
+    expect(config.formatters.first.formatter).to be_a(klass)
+  end
+
+  [OldStyleFormatterExample, LegacyFormatterUsingSubClassing].each do |klass|
+
+    describe "#{klass}" do
+      let(:described_class) { klass }
+
+      describe "#start" do
+        it "notifies formatter of start" do
+          send_notification :start, start_notification(5)
+          expect(output.string).to include "Started 5 examples"
+        end
+      end
+
+      describe "#example_group_started" do
+        it "notifies formatter of example_group_started" do
+          send_notification :example_group_started, group_notification
+          expect(output.string).to include "Started Group"
+        end
+      end
+
+      describe "#example_group_finished" do
+        it "notifies formatter of example_group_finished" do
+          send_notification :example_group_finished, group_notification
+          expect(output.string).to include "Finished Group"
+        end
+      end
+
+      describe "#example_started" do
+        it "notifies formatter of example_started" do
+          send_notification :example_started, example_notification
+          expect(output.string).to include "Started Example"
+        end
+      end
+
+      describe "#example_passed" do
+        it "notifies formatter of example_passed" do
+          send_notification :example_passed, example_notification
+          expect(output.string).to include "."
+        end
+      end
+
+      describe "#example_pending" do
+        it "notifies formatter of example_pending" do
+          send_notification :example_pending, example_notification
+          expect(output.string).to include "P"
+        end
+      end
+
+      describe "#example_failed" do
+        it "notifies formatter of example_failed" do
+          send_notification :example_failed, example_notification
+          expect(output.string).to include "F"
+        end
+      end
+
+      describe "#message" do
+        it "notifies formatter of message" do
+          send_notification :message, message_notification("A Message")
+          expect(output.string).to include "A Message"
+        end
+      end
+
+      describe "#stop" do
+        it "notifies formatter of stop" do
+          send_notification :stop, null_notification
+          expect(output.string).to include "Stopped"
+        end
+      end
+
+      describe "#start_dump" do
+        it "notifies formatter of start_dump" do
+          send_notification :start_dump, null_notification
+          expect(output.string).to include "Dumping!"
+        end
+      end
+
+      describe "#dump_failures" do
+        it "notifies formatter of dump_failures" do
+          send_notification :dump_failures, null_notification
+          expect(output.string).to include "Failures:"
+        end
+      end
+
+      describe "#dump_summary" do
+        it "notifies formatter of dump_summary" do
+          duration, count, failures, pending = 3.5, 10, 3, 2
+          send_notification :dump_summary, summary_notification(duration, count, failures, pending, 0)
+          expect(output.string).to(
+                match("Finished in 3.5").
+            and match("3/10 failed.").
+            and match("2 pending.")
+          )
+        end
+      end
+
+      describe "#dump_pending" do
+        it "notifies formatter of dump_pending" do
+          send_notification :dump_pending, null_notification
+          expect(output.string).to match "Pending:"
+        end
+      end
+
+      describe "#seed" do
+        it "notifies formatter of seed" do
+          send_notification :seed, seed_notification(17)
+          expect(output.string).to match "Randomized with seed 17"
+        end
+      end
+
+      describe "#close" do
+        it "notifies formatter of close" do
+          send_notification :close, null_notification
+        end
+      end
+    end
+  end
+
+  describe LegacyFormatterUsingSubClassing do
+    let(:legacy_formatter) { formatter.formatter }
+
+    it "will lookup colour codes" do
+      expect(legacy_formatter.color_code_for(:black)).to eq 30
+    end
+
+    it "will colorize text" do
+      allow(RSpec.configuration).to receive(:color_enabled?) { true }
+      expect(legacy_formatter.colorize("text", :black)).to eq "\e[30mtext\e[0m"
+    end
+
+    it "will colorize summary" do
+      allow(RSpec.configuration).to receive(:color_enabled?) { true }
+      expect(legacy_formatter.colorize_summary("text")).to include "\e[32mtext\e[0m"
+    end
+
+    it "allows access to the deprecated constants" do
+      pending "caller filter update"
+      legacy_formatter
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)
+      expect(described_class::VT100_COLORS).to eq ::RSpec::Core::Formatters::ConsoleCodes::VT100_CODES
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)
+      expect(described_class::VT100_COLOR_CODES).to eq ::RSpec::Core::Formatters::ConsoleCodes::VT100_CODE_VALUES
+    end
+
+    ::RSpec::Core::Formatters::ConsoleCodes::VT100_CODES.each do |name, number|
+      next if name == :black || name == :bold
+
+      describe "##{name}" do
+        before do
+          allow(RSpec.configuration).to receive(:color_enabled?) { true }
+          allow(RSpec).to receive(:deprecate)
+        end
+
+        it "prints the text using the color code for #{name}" do
+          expect(legacy_formatter.send(name, "text")).to eq("\e[#{number}mtext\e[0m")
+        end
+
+        it "prints a deprecation warning" do
+          expect(RSpec).to receive(:deprecate) {|*args|
+            expect(args.first).to match(/#{name}/)
+          }
+          legacy_formatter.send(name, "text")
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'rspec/support/spec'
+RSpec::Support::Spec.setup_simplecov
+
+Dir['./spec/support/**/*.rb'].map { |f| require f }

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -1,0 +1,83 @@
+module FormatterSupport
+
+  def send_notification type, notification
+    reporter.notify type, notification
+  end
+
+  def reporter
+    @reporter ||= setup_reporter
+  end
+
+  def setup_reporter(*streams)
+    config.add_formatter described_class, *streams
+    @formatter = config.formatters.first
+    @reporter = config.reporter
+  end
+
+  def output
+    @output ||= StringIO.new
+  end
+
+  def config
+    @configuration ||=
+      begin
+        config = RSpec::Core::Configuration.new
+        config.output_stream = output
+        config
+      end
+  end
+
+  def configure
+    yield config
+  end
+
+  def formatter
+    @formatter ||=
+      begin
+        setup_reporter
+        @formatter
+      end
+  end
+
+  def example
+    instance_double("RSpec::Core::Example",
+                    :description      => "Example",
+                    :full_description => "Example",
+                    :execution_result => { :exception => Exception.new },
+                    :metadata         => {}
+                   )
+  end
+
+  def group
+    class_double "RSpec::Core::ExampleGroup", :description => "Group"
+  end
+
+  def start_notification(count)
+   ::RSpec::Core::Notifications::StartNotification.new count
+  end
+
+  def example_notification(specific_example = example)
+   ::RSpec::Core::Notifications::ExampleNotification.new specific_example
+  end
+
+  def group_notification
+   ::RSpec::Core::Notifications::GroupNotification.new group
+  end
+
+  def message_notification(message)
+    ::RSpec::Core::Notifications::MessageNotification.new message
+  end
+
+  def null_notification
+    ::RSpec::Core::Notifications::NullNotification
+  end
+
+  def seed_notification(seed, used = true)
+    ::RSpec::Core::Notifications::SeedNotification.new seed, used
+  end
+
+  def summary_notification(duration, examples, failed, pending, time)
+    ::RSpec::Core::Notifications::SummaryNotification.new duration, examples, failed, pending, time
+  end
+
+end

--- a/spec/support/legacy_formatter_using_sub_classing_example.rb
+++ b/spec/support/legacy_formatter_using_sub_classing_example.rb
@@ -1,0 +1,87 @@
+require 'rspec/core/formatters/base_text_formatter'
+
+class LegacyFormatterUsingSubClassing < RSpec::Core::Formatters::BaseTextFormatter
+
+  def initialize(output)
+    super nil
+    @output = output
+  end
+
+  def start(example_count)
+    super
+    @output.puts "Started #{example_count.to_s} examples"
+  end
+
+  def example_group_started(group)
+    super
+    @output.puts "Started #{group.description}"
+  end
+
+  def example_group_finished(group)
+    super
+    @output.puts "Finished #{group.description}"
+  end
+
+  def example_started(example)
+    super
+    @output.puts "Started #{example.full_description}"
+  end
+
+  def stop
+    super
+    @output.puts "Stopped"
+  end
+
+  def message(message)
+    super
+    @output.puts message
+  end
+
+  def dump_failures
+    super
+    @output.puts "Failures:"
+  end
+
+  def dump_summary(duration, example_count, failure_count, pending_count)
+    super
+    @output.puts "\nFinished in #{duration}\n" +
+                 "#{failure_count}/#{example_count} failed.\n" +
+                 "#{pending_count} pending."
+  end
+
+  def dump_pending
+    super
+    @output.puts "Pending:"
+  end
+
+  def seed(number)
+    super
+    @output.puts "Randomized with seed #{number}"
+  end
+
+  def close
+    super
+    @output.close
+  end
+
+  def example_passed(example)
+    super
+    @output.print '.'
+  end
+
+  def example_pending(example)
+    super
+    @output.print 'P'
+  end
+
+  def example_failed(example)
+    super
+    @output.print 'F'
+  end
+
+  def start_dump
+    super
+    @output.puts "Dumping!"
+  end
+
+end

--- a/spec/support/old_style_formatter_example.rb
+++ b/spec/support/old_style_formatter_example.rb
@@ -1,0 +1,69 @@
+class OldStyleFormatterExample
+
+  def initialize(output)
+    @output = output
+  end
+
+  def start(example_count)
+    @output.puts "Started #{example_count.to_s} examples"
+  end
+
+  def example_group_started(group)
+    @output.puts "Started #{group.description}"
+  end
+
+  def example_group_finished(group)
+    @output.puts "Finished #{group.description}"
+  end
+
+  def example_started(example)
+    @output.puts "Started #{example.full_description}"
+  end
+
+  def stop
+    @output.puts "Stopped"
+  end
+
+  def message(message)
+    @output.puts message
+  end
+
+  def dump_failures
+    @output.puts "Failures:"
+  end
+
+  def dump_summary(duration, example_count, failure_count, pending_count)
+    @output.puts "\nFinished in #{duration}\n" +
+                 "#{failure_count}/#{example_count} failed.\n" +
+                 "#{pending_count} pending."
+  end
+
+  def dump_pending
+    @output.puts "Pending:"
+  end
+
+  def seed(number)
+    @output.puts "Randomized with seed #{number}"
+  end
+
+  def close
+    @output.close
+  end
+
+  def example_passed(example)
+    @output.print '.'
+  end
+
+  def example_pending(example)
+    @output.print 'P'
+  end
+
+  def example_failed(example)
+    @output.print 'F'
+  end
+
+  def start_dump
+    @output.puts "Dumping!"
+  end
+
+end


### PR DESCRIPTION
This is just the old support from core, rewired to work we the wip branch on core.
