### PR TITLE
Use proper rbx tag for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ rvm:
   - ree
   - jruby-18mode
   - jruby
-  - rbx
+  - rbx-2
 matrix:
-  allow_failures:
-    - rvm: rbx
   fast_finish: true


### PR DESCRIPTION
Travis / RVM switched to needing `rbx-2` for triggering Rubinius builds, and there's not need to ignore failures because it passes!
