### PR TITLE
2 fixes

### DIFF
--- a/rspec-legacy_formatters.gemspec
+++ b/rspec-legacy_formatters.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
     spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  spec.add_runtime_dependency     "rspec",    "~> 3.0.0"
+  spec.add_runtime_dependency     "rspec",    ">= 3.0.0", '< 4.0.0'
 
   spec.add_development_dependency "cucumber", "~> 1.3"
   spec.add_development_dependency "aruba",    "~> 0.5"


### PR DESCRIPTION
* rspec/core needs to be required
* update gemspec versioning to allow this gem to be used with all Rspec 3.x.x versions