### PR TITLE
Smoke test all formatters and fix HTML formatter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+### Development
+
+Bug Fixes:
+
+* Fix formatters using / extending the legacy HTML formatter which would crash
+  due to a change in the `SnippetExtractor` in RSpec 3.4. (Jon Rowe, #22)
+
 ### 1.0.1 / 2015-11-05
 [Full Changelog](http://github.com/rspec/rspec-legacy_formatters/compare/v1.0.0...v1.0.1)
 

--- a/lib/rspec/legacy_formatters/html_formatter.rb
+++ b/lib/rspec/legacy_formatters/html_formatter.rb
@@ -1,5 +1,6 @@
 require 'rspec/legacy_formatters/base_text_formatter'
 require 'rspec/legacy_formatters/html_printer'
+require 'rspec/legacy_formatters/snippet_extractor'
 
 module RSpec
   module Core

--- a/lib/rspec/legacy_formatters/snippet_extractor.rb
+++ b/lib/rspec/legacy_formatters/snippet_extractor.rb
@@ -46,7 +46,9 @@ module RSpec
         def snippet(backtrace)
           raw_code, line = snippet_for(backtrace[0])
           highlighted = @@converter.convert(raw_code)
-          highlighted << "\n<span class=\"comment\"># gem install syntax to get syntax highlighting</span>" if @@converter.is_a?(NullConverter)
+          if LegacyNullConverter == @@converter || (defined?(NullConverter) && @@converter.is_a?(NullConverter))
+            highlighted << "\n<span class=\"comment\"># gem install syntax to get syntax highlighting</span>"
+          end
           post_process(highlighted, line)
         end
 

--- a/lib/rspec/legacy_formatters/snippet_extractor.rb
+++ b/lib/rspec/legacy_formatters/snippet_extractor.rb
@@ -1,6 +1,8 @@
 module RSpec
   module Core
     module Formatters
+      remove_const :SnippetExtractor
+
       # @api private
       #
       # Extracts code snippets by looking at the backtrace of the passed error and applies synax highlighting and line numbers using html.
@@ -23,6 +25,14 @@ module RSpec
           @@converter = Syntax::Convertors::HTML.for_syntax "ruby"
         rescue LoadError
           @@converter = LegacyNullConverter
+        end
+
+        # Copied from the 3.4 version, but with default overrides to cope with
+        # our usage
+        def initialize(source=nil, beginning_line_number=nil, max_line_count=nil)
+          @source = source
+          @beginning_line_number = beginning_line_number
+          @max_line_count = max_line_count
         end
 
         # @api private

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -97,8 +97,13 @@ function run_specs_as_version {
     bundle_install_flags=`cat ../.travis.yml | grep bundler_args | tr -d '"' | grep -o " .*"`
     travis_retry bundle install $bundle_install_flags
     cp ../.rspec .rspec
+
+    # First check that we can run our spec suite
+    bin/rspec ../spec --format NyanCatFormatter --format NyanCatFormatter
+
     set +e
-    bin/rspec spec ../spec --format NyanCatFormatter --format NyanCatFormatter --out $SPECS_HAVE_RUN_FILE
+    # Then check we can run the smoke suite
+    bin/rspec spec --format NyanCatFormatter --format NyanCatFormatter --out $SPECS_HAVE_RUN_FILE
     local status=$?
     set -e
     popd

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -87,7 +87,7 @@ function run_specs_and_record_done {
   $rspec_bin spec --backtrace --format progress --profile --format progress --out $SPECS_HAVE_RUN_FILE
 }
 
-function run_sample_specs {
+function run_specs_as_version {
   if [ ! -f ./smoke_specs/$SPECS_HAVE_RUN_FILE ]; then # don't rerun specs that have already run
     pushd ./smoke_specs
     echo

--- a/script/functions.sh
+++ b/script/functions.sh
@@ -102,6 +102,19 @@ function run_specs_as_version {
     bin/rspec ../spec --format NyanCatFormatter --format NyanCatFormatter
 
     set +e
+    # Then check RSpec 2.x formatters
+    bin/rspec spec -r ../lib/rspec/legacy_formatters/documentation_formatter.rb --format RSpec::Core::Formatters::DocumentationFormatter
+    local documentation_status=$?
+
+    bin/rspec spec -r ../lib/rspec/legacy_formatters/json_formatter.rb --format RSpec::Core::Formatters::JsonFormatter
+    local json_status=$?
+
+    bin/rspec spec -r ../lib/rspec/legacy_formatters/html_formatter.rb --format RSpec::Core::Formatters::HtmlFormatter
+    local html_status=$?
+
+    bin/rspec spec -r ../lib/rspec/legacy_formatters/progress_formatter.rb --format RSpec::Core::Formatters::ProgressFormatter
+    local progress_status=$?
+
     # Then check we can run the smoke suite
     bin/rspec spec --format NyanCatFormatter --format NyanCatFormatter --out $SPECS_HAVE_RUN_FILE
     local status=$?
@@ -109,7 +122,13 @@ function run_specs_as_version {
     popd
     # 42 is set in the rspec config for the smoke tests,
     # so we can differentiate between crashes and real failures
-    if test $status = 42; then
+    if
+      (test $status = 42) &&
+      (test $documentation_status = 42) &&
+      (test $json_status = 42) &&
+      (test $html_status = 42) &&
+      (test $progress_status = 42)
+    then
       echo "Build passed"
       return 0
     else

--- a/script/run_build
+++ b/script/run_build
@@ -7,7 +7,7 @@ source script/functions.sh
 
 # We can't run our normal specs with all versions of rspec
 if rspec_version_defined; then
-  run_sample_specs
+  run_specs_as_version
 else
   run_specs_and_record_done
   run_cukes

--- a/spec/support/formatter_support.rb
+++ b/spec/support/formatter_support.rb
@@ -42,6 +42,7 @@ module FormatterSupport
   def example
     instance_double("RSpec::Core::Example",
                     :description      => "Example",
+                    :example_group    => group,
                     :full_description => "Example",
                     :execution_result => instance_double(RSpec::Core::Example::ExecutionResult, :exception => Exception.new).as_null_object ,
                     :metadata         => {}
@@ -49,7 +50,12 @@ module FormatterSupport
   end
 
   def group
-    class_double "RSpec::Core::ExampleGroup", :description => "Group"
+    class_double(
+      "RSpec::Core::ExampleGroup",
+      :description => "Group",
+      :parent_groups => [],
+      :top_level? => false
+    )
   end
 
   def start_notification(count)


### PR DESCRIPTION
#18 brings to light a problem with the test suite of this gem, namely that although it tested the mechanics of its conversion stuff, it didn't actually test that the back ported formatters worked. In addition it swallowed failures from its own test suite when run with legacy formatters.

This PR fixes the build so that all the formatters are tested, fixes the build for the legacy formatters and fixes the HTML formatter.

Closes #18 